### PR TITLE
Support for Amazon.de

### DIFF
--- a/chrome/manifest.json
+++ b/chrome/manifest.json
@@ -12,7 +12,8 @@
     {
       "matches": [
         "https://www.amazon.ca/*returns/label/*",
-        "https://www.amazon.com/*returns/label/*"
+        "https://www.amazon.com/*returns/label/*",
+	"https://www.amazon.de/*/returns/label/*"
       ],
       "js": ["js/amazonreturnonepager.js"],
       "run_at": "document_start"

--- a/firefox/manifest.json
+++ b/firefox/manifest.json
@@ -12,7 +12,8 @@
     {
       "matches": [
         "https://www.amazon.ca/*returns/label/*",
-        "https://www.amazon.com/*returns/label/*"
+        "https://www.amazon.com/*returns/label/*",
+	"https://www.amazon.de/*/returns/label/*"
       ],
       "js": ["js/amazonreturnonepager.js"],
       "run_at": "document_start"


### PR DESCRIPTION
I've added the URL for amazon.de for both Chrome and Firefox manifest.json. Result is as expected. 👍🏻
Thanks, for this awesome extension. 

Unfortunately, I cannot test it with any other Amazon website, I only have recent orders with Amazon.de
